### PR TITLE
Allow the version 13 of `rake`

### DIFF
--- a/rack-protection-maximum_cookie.gemspec
+++ b/rack-protection-maximum_cookie.gemspec
@@ -28,5 +28,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'bundler', '>= 1.15', '< 3'
   spec.add_development_dependency 'minitest', '~> 5.0'
   spec.add_development_dependency 'rack-test', '>= 0.7.0', '< 2'
-  spec.add_development_dependency 'rake', '~> 12.0'
+  spec.add_development_dependency 'rake', '>= 12.0', '< 14'
 end


### PR DESCRIPTION
And it'd be nice to make a new release of gem after merging this.